### PR TITLE
[#16] Team 생성, 조회 API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,5 @@ out/
 ### VS Code ###
 .vscode/
 
-# Ignore application.yaml
-application.yml
 
 

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ out/
 ### VS Code ###
 .vscode/
 
-# Ignore .env file
-.env
+# Ignore application.yaml
+application.yml
+
 

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ out/
 
 ### VS Code ###
 .vscode/
+
+# Ignore .env file
+.env
+

--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,7 @@ dependencies {
     implementation 'org.hibernate.validator:hibernate-validator:7.0.5.Final'
     implementation 'org.glassfish:jakarta.el:4.0.2'
 
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
 
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,11 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    implementation 'jakarta.validation:jakarta.validation-api:3.0.2'
+    implementation 'org.hibernate.validator:hibernate-validator:7.0.5.Final'
+    implementation 'org.glassfish:jakarta.el:4.0.2'
+
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,7 @@ dependencies {
     implementation 'org.hibernate.validator:hibernate-validator:7.0.5.Final'
     implementation 'org.glassfish:jakarta.el:4.0.2'
 
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/maptracker/issuemap/common/global/SecurityConfig.java
+++ b/src/main/java/com/maptracker/issuemap/common/global/SecurityConfig.java
@@ -1,0 +1,24 @@
+package com.maptracker.issuemap.common.global;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable) // CSRF 비활성화
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll() // Swagger 관련 경로 허용
+                        .requestMatchers("/api/teams/**").permitAll() // API 경로 허용
+                        .anyRequest().authenticated() // 그 외 요청 인증 필요
+                )
+                .httpBasic(httpBasic -> httpBasic.realmName("YourRealm")); // HTTP Basic 인증 활성화 및 Realm 설정
+        return http.build();
+    }
+}

--- a/src/main/java/com/maptracker/issuemap/domain/team/controller/TeamController.java
+++ b/src/main/java/com/maptracker/issuemap/domain/team/controller/TeamController.java
@@ -1,0 +1,50 @@
+package com.maptracker.issuemap.domain.team.controller;
+
+import com.maptracker.issuemap.domain.team.dto.TeamRequestDto;
+import com.maptracker.issuemap.domain.team.dto.TeamResponseDto;
+import com.maptracker.issuemap.domain.team.service.TeamService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/teams")
+@RequiredArgsConstructor
+public class TeamController {
+
+    private final TeamService teamService;
+
+    @Operation(
+            summary = "팀 생성 API",
+            description = "새로운 팀을 생성합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "팀 생성 성공",
+                            content = @Content(schema = @Schema(implementation = TeamResponseDto.class))),
+                    @ApiResponse(responseCode = "400", description = "잘못된 요청 데이터")
+            }
+    )
+    @PostMapping
+    public ResponseEntity<TeamResponseDto> createTeam(@RequestBody TeamRequestDto teamRequestDto) {
+        TeamResponseDto teamResponseDto = teamService.createTeam(teamRequestDto);
+        return ResponseEntity.ok(teamResponseDto);
+    }
+
+    @Operation(
+            summary = "팀 조회 API",
+            description = "팀 ID를 기반으로 팀 정보를 조회합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "팀 조회 성공",
+                            content = @Content(schema = @Schema(implementation = TeamResponseDto.class))),
+                    @ApiResponse(responseCode = "404", description = "팀을 찾을 수 없음")
+            }
+    )
+    @GetMapping("/{teamId}")
+    public ResponseEntity<TeamResponseDto> getTeam(@PathVariable Long teamId) {
+        TeamResponseDto teamResponseDto = teamService.getTeam(teamId);
+        return ResponseEntity.ok(teamResponseDto);
+    }
+}

--- a/src/main/java/com/maptracker/issuemap/domain/team/dto/TeamRequestDto.java
+++ b/src/main/java/com/maptracker/issuemap/domain/team/dto/TeamRequestDto.java
@@ -1,0 +1,17 @@
+package com.maptracker.issuemap.domain.team.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class TeamRequestDto {
+    private String teamName;
+    private List<String> memberEmails;
+}

--- a/src/main/java/com/maptracker/issuemap/domain/team/dto/TeamRequestDto.java
+++ b/src/main/java/com/maptracker/issuemap/domain/team/dto/TeamRequestDto.java
@@ -1,5 +1,6 @@
 package com.maptracker.issuemap.domain.team.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -12,6 +13,13 @@ import java.util.List;
 @AllArgsConstructor
 @Builder
 public class TeamRequestDto {
+
+    @Schema(description = "팀 이름", example = "Development Team")
     private String teamName;
+
+    @Schema(
+            description = "팀 멤버 이메일 목록",
+            example = "[\"member1@example.com\", \"member2@example.com\"]"
+    )
     private List<String> memberEmails;
 }

--- a/src/main/java/com/maptracker/issuemap/domain/team/dto/TeamResponseDto.java
+++ b/src/main/java/com/maptracker/issuemap/domain/team/dto/TeamResponseDto.java
@@ -1,5 +1,6 @@
 package com.maptracker.issuemap.domain.team.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -12,7 +13,16 @@ import java.util.List;
 @AllArgsConstructor
 @Builder
 public class TeamResponseDto {
+
+    @Schema(description = "팀 ID", example = "1")
     private Long id;
+
+    @Schema(description = "팀 이름", example = "Development Team")
     private String teamName;
+
+    @Schema(
+            description = "팀 멤버 이메일 목록",
+            example = "[\"member1@example.com\", \"member2@example.com\"]"
+    )
     private List<String> memberEmails;
 }

--- a/src/main/java/com/maptracker/issuemap/domain/team/dto/TeamResponseDto.java
+++ b/src/main/java/com/maptracker/issuemap/domain/team/dto/TeamResponseDto.java
@@ -1,0 +1,18 @@
+package com.maptracker.issuemap.domain.team.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class TeamResponseDto {
+    private Long id;
+    private String teamName;
+    private List<String> memberEmails;
+}

--- a/src/main/java/com/maptracker/issuemap/domain/team/entity/Team.java
+++ b/src/main/java/com/maptracker/issuemap/domain/team/entity/Team.java
@@ -1,11 +1,15 @@
 package com.maptracker.issuemap.domain.team.entity;
 import com.maptracker.issuemap.domain.project.entity.Project;
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+
 import java.util.List;
 
 @Entity
 @Getter
+@NoArgsConstructor
 public class Team {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -17,4 +21,9 @@ public class Team {
 
     @OneToMany(mappedBy = "team", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Project> projects;
+
+    @Builder
+    public Team(String teamName) {
+        this.teamName = teamName;
+    }
 }

--- a/src/main/java/com/maptracker/issuemap/domain/team/entity/Team.java
+++ b/src/main/java/com/maptracker/issuemap/domain/team/entity/Team.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Entity
@@ -19,11 +20,17 @@ public class Team {
     @Column(name = "team_name", nullable = false)
     private String teamName;
 
+    @ElementCollection(fetch = FetchType.EAGER) // 즉시 로딩으로 설정
+    @CollectionTable(name = "team_member_emails", joinColumns = @JoinColumn(name = "team_id")) // 매핑 테이블 명시
+    @Column(name = "member_email") // 컬럼 이름 지정
+    private List<String> memberEmails;
+
     @OneToMany(mappedBy = "team", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Project> projects;
 
     @Builder
-    public Team(String teamName) {
+    public Team(String teamName, List<String> memberEmails) {
         this.teamName = teamName;
+        this.memberEmails = memberEmails != null ? memberEmails : new ArrayList<>();
     }
 }

--- a/src/main/java/com/maptracker/issuemap/domain/team/service/TeamService.java
+++ b/src/main/java/com/maptracker/issuemap/domain/team/service/TeamService.java
@@ -1,0 +1,45 @@
+package com.maptracker.issuemap.domain.team.service;
+import com.maptracker.issuemap.domain.team.entity.Team;
+import com.maptracker.issuemap.domain.team.dto.TeamRequestDto;
+import com.maptracker.issuemap.domain.team.dto.TeamResponseDto;
+import com.maptracker.issuemap.domain.team.repository.TeamRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class TeamService {
+    private final TeamRepository teamRepository;
+
+    // 팀 생성
+    public TeamResponseDto createTeam(TeamRequestDto teamRequestDto) {
+        Team team = Team.builder()
+                        .teamName(teamRequestDto.getTeamName())
+                        .memberEmails(teamRequestDto.getMemberEmails())
+                        .build();
+
+        Team savedTeam = teamRepository.save(team);
+
+        return TeamResponseDto.builder()
+                .id(savedTeam.getId())
+                .teamName(savedTeam.getTeamName())
+                .memberEmails(savedTeam.getMemberEmails())
+                .build();
+    }
+
+    // 팀 조회
+    public TeamResponseDto getTeam(Long teamId){
+        Team team = teamRepository.findById(teamId)
+                .orElseThrow(() -> new IllegalArgumentException("Team not found with id: " + teamId));
+
+        return TeamResponseDto.builder()
+                .id(team.getId())
+                .teamName(team.getTeamName())
+                .memberEmails(team.getMemberEmails())
+                .build();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,10 +4,16 @@ spring:
   datasource:
     url: jdbc:mysql://localhost:3306/issuemap
     username: root
-    password:
+    password: root1234!@
     driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     show-sql: true
     open-in-view: false
     hibernate:
       ddl-auto: update
+  security:
+    user:
+      name: user
+      password: user123
+    enabled: false
+

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,7 +4,7 @@ spring:
   datasource:
     url: jdbc:mysql://localhost:3306/issuemap
     username: root
-    password: ${DB_PASSWORD}
+    password: root1234!@
     driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     show-sql: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,9 +2,9 @@ spring:
   application:
     name: issuemap
   datasource:
-    url:
-    username:
-    password:
+    url: jdbc:mysql://localhost:3306/issuemap
+    username: root
+    password: ${DB_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     show-sql: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,7 +4,7 @@ spring:
   datasource:
     url: jdbc:mysql://localhost:3306/issuemap
     username: root
-    password: root1234!@
+    password:
     driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     show-sql: true


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [X] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 코드 리팩토링
- [ ] 테스트 코드 추가 및 리팩토링
- [X] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
develop

### 이슈
[#16   ]

### 변경 사항
1. Team dto 생성
2. validation 의존성 추가
3. swagger 관련 의존성 추가
4. swagger 사용 위해 securityconfig 추가 및 applicaiton.yml에 security 추가
5. 엔티티 수정 - 팀 생성 및 조회시 memberEmail을 추가, 조회하기 위해(팀원초대 및 조회)
6. 팀 생성 및 조회 api 추가
참고) application.yml에 DB password 를 환경변수 처리하거나 해당 파일을 gitignore 처리하고 싶었으나
이미 파일이 올라가 설정이 복잡해 일단 password는 지우고 push 했습니다.

### 테스트 결과
[스웨거 사용해 테스트 했습니다.]
팀 생성 API 
<img width="1160" alt="팀 생성 API 1" src="https://github.com/user-attachments/assets/2dd33a1d-f0de-4b31-85d5-1cd183c69310" />
<img width="1186" alt="팀 생성 API 2" src="https://github.com/user-attachments/assets/0c9869b1-216e-4255-99b8-7dcd4ce9b04b" />
팀 조회 API
<img width="945" alt="팀 조회 API " src="https://github.com/user-attachments/assets/21d8a002-52f8-4fb3-b3eb-402fc9daf88d" />


 
