### PR TITLE
[#35] 로그아웃 API 구현

### DIFF
--- a/src/main/java/com/maptracker/issuemap/common/config/SecurityConfig.java
+++ b/src/main/java/com/maptracker/issuemap/common/config/SecurityConfig.java
@@ -1,7 +1,7 @@
 package com.maptracker.issuemap.common.config;
 
-import com.maptracker.issuemap.common.jwt.JWTFilter;
-import com.maptracker.issuemap.common.jwt.JWTUtil;
+import com.maptracker.issuemap.common.jwt.JwtFilter;
+import com.maptracker.issuemap.common.jwt.JwtUtil;
 import com.maptracker.issuemap.common.jwt.LoginFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -23,7 +23,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfig {
 
     private final AuthenticationConfiguration authenticationConfiguration;
-    private final JWTUtil jwtUtil;
+    private final JwtUtil jwtUtil;
 
     @Bean
     public PasswordEncoder passwordEncoder() {
@@ -71,7 +71,7 @@ public class SecurityConfig {
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS));
 
         http
-                .addFilterBefore(new JWTFilter(jwtUtil), LoginFilter.class);
+                .addFilterBefore(new JwtFilter(jwtUtil), LoginFilter.class);
 
         LoginFilter loginFilter = new LoginFilter(authenticationManager(authenticationConfiguration), jwtUtil);
         loginFilter.setFilterProcessesUrl("/api/users/login");

--- a/src/main/java/com/maptracker/issuemap/common/config/SwaggerConfig.java
+++ b/src/main/java/com/maptracker/issuemap/common/config/SwaggerConfig.java
@@ -1,0 +1,27 @@
+package com.maptracker.issuemap.common.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+    @Bean
+    public OpenAPI customOpenAPI() {
+        SecurityScheme securityScheme = new SecurityScheme()
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat("JWT");
+
+        return new OpenAPI()
+                .components(new Components().addSecuritySchemes("BearerAuth", securityScheme))
+                .addSecurityItem(new SecurityRequirement().addList("BearerAuth"))
+                .info(new Info().title("API Documentation")
+                        .description("API 설명")
+                        .version("1.0.0"));
+    }
+}

--- a/src/main/java/com/maptracker/issuemap/common/jwt/JwtFilter.java
+++ b/src/main/java/com/maptracker/issuemap/common/jwt/JwtFilter.java
@@ -8,13 +8,19 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
 
+@Slf4j
 @RequiredArgsConstructor
 public class JwtFilter extends OncePerRequestFilter {
+
+    public static final String BEARER_PREFIX = "Bearer ";
+    public static final String ACCESS_TOKEN_HEADER = "Authorization";
+    public static final String REFRESH_TOKEN_HEADER = "Refresh-Token";
 
     private final JwtUtil jwtUtil;
 
@@ -22,21 +28,40 @@ public class JwtFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
 
-        String authorization = request.getHeader("Authorization");
+        String accessToken = extractToken(request, ACCESS_TOKEN_HEADER);
+        String refreshToken = extractToken(request, REFRESH_TOKEN_HEADER);
 
-        if (authorization == null || !authorization.startsWith("Bearer ")) {
+        if (accessToken == null && refreshToken == null) {
             filterChain.doFilter(request, response);
             return;
         }
 
-        String token = authorization.split(" ")[1];
-
-        if (jwtUtil.isExpired(token)) {
-            filterChain.doFilter(request, response);
+        if ((accessToken == null || jwtUtil.isExpired(accessToken)) && (refreshToken == null || jwtUtil.isExpired(refreshToken))) {
+            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Access and Refresh tokens are expired. Please login again.");
             return;
         }
 
-        String userEmail = jwtUtil.getUserEmail(token);
+        if ((accessToken == null || jwtUtil.isExpired(accessToken)) && refreshToken != null && !jwtUtil.isExpired(refreshToken)) {
+            String userEmail = jwtUtil.getUserEmail(refreshToken);
+            String newAccessToken = jwtUtil.createJwt(userEmail, 60 * 60L);
+            response.setHeader(ACCESS_TOKEN_HEADER, BEARER_PREFIX + newAccessToken);
+            setAuthentication(userEmail);
+            accessToken = newAccessToken;
+        }
+
+        if (accessToken != null && !jwtUtil.isExpired(accessToken)
+                && (refreshToken == null || jwtUtil.isExpired(refreshToken))) {
+            String userEmail = jwtUtil.getUserEmail(accessToken);
+            String newRefreshToken = jwtUtil.createJwt(userEmail, 60 * 60L * 24L * 7L);
+            response.setHeader(REFRESH_TOKEN_HEADER, BEARER_PREFIX + newRefreshToken);
+        }
+
+        if (accessToken != null && !jwtUtil.isExpired(accessToken)) {
+            String userEmail = jwtUtil.getUserEmail(accessToken);
+            setAuthentication(userEmail);
+        }
+
+        String userEmail = jwtUtil.getUserEmail(accessToken);
         User userEntity = User.builder()
                 .email(userEmail)
                 .password("temp")
@@ -48,4 +73,25 @@ public class JwtFilter extends OncePerRequestFilter {
         SecurityContextHolder.getContext().setAuthentication(authToken);
         filterChain.doFilter(request, response);
     }
+
+    private void setAuthentication(String userEmail) {
+        User userEntity = User.builder()
+                .email(userEmail)
+                .password("temp")
+                .build();
+
+        CustomUserDetails customUserDetails = new CustomUserDetails(userEntity);
+        Authentication authToken = new UsernamePasswordAuthenticationToken(customUserDetails, null,
+                customUserDetails.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(authToken);
+    }
+
+    private String extractToken(HttpServletRequest request, String headerName) {
+        String header = request.getHeader(headerName);
+        if (header != null && header.startsWith(BEARER_PREFIX)) {
+            return header.substring(BEARER_PREFIX.length());
+        }
+        return null;
+    }
+
 }

--- a/src/main/java/com/maptracker/issuemap/common/jwt/JwtFilter.java
+++ b/src/main/java/com/maptracker/issuemap/common/jwt/JwtFilter.java
@@ -14,9 +14,9 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 @RequiredArgsConstructor
-public class JWTFilter extends OncePerRequestFilter {
+public class JwtFilter extends OncePerRequestFilter {
 
-    private final JWTUtil jwtUtil;
+    private final JwtUtil jwtUtil;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)

--- a/src/main/java/com/maptracker/issuemap/common/jwt/JwtUtil.java
+++ b/src/main/java/com/maptracker/issuemap/common/jwt/JwtUtil.java
@@ -10,11 +10,11 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 @Component
-public class JWTUtil {
+public class JwtUtil {
 
     private Key key;
 
-    public JWTUtil(@Value("${spring.jwt.secret}") String secret) {
+    public JwtUtil(@Value("${spring.jwt.secret}") String secret) {
         byte[] keyBytes = Decoders.BASE64.decode(secret);
         this.key = Keys.hmacShaKeyFor(keyBytes);
     }

--- a/src/main/java/com/maptracker/issuemap/common/jwt/LoginFilter.java
+++ b/src/main/java/com/maptracker/issuemap/common/jwt/LoginFilter.java
@@ -60,8 +60,10 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
         CustomUserDetails customUserDetails = (CustomUserDetails) authResult.getPrincipal();
         String userEmail = customUserDetails.getUsername();
 
-        String token = jwtUtil.createJwt(userEmail, 60 * 60 * 10L);
-        response.addHeader("Authorization", "Bearer " + token);
+        String accessToken = jwtUtil.createJwt(userEmail, 60 * 60L);
+        String refreshToken = jwtUtil.createJwt(userEmail, 60 * 60 * 10L);
+        response.addHeader("Authorization", "Bearer " + accessToken);
+        response.addHeader("Refresh-Token", "Bearer " + refreshToken);
     }
 
     @Override

--- a/src/main/java/com/maptracker/issuemap/common/jwt/LoginFilter.java
+++ b/src/main/java/com/maptracker/issuemap/common/jwt/LoginFilter.java
@@ -28,7 +28,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class LoginFilter extends UsernamePasswordAuthenticationFilter {
 
     private final AuthenticationManager authenticationManager;
-    private final JWTUtil jwtUtil;
+    private final JwtUtil jwtUtil;
 
     @Override
     public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response)

--- a/src/main/java/com/maptracker/issuemap/common/jwt/LoginFilter.java
+++ b/src/main/java/com/maptracker/issuemap/common/jwt/LoginFilter.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.maptracker.issuemap.domain.user.dto.CustomUserDetails;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.BufferedReader;
@@ -60,10 +61,24 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
         CustomUserDetails customUserDetails = (CustomUserDetails) authResult.getPrincipal();
         String userEmail = customUserDetails.getUsername();
 
-        String accessToken = jwtUtil.createJwt(userEmail, 60 * 60L);
-        String refreshToken = jwtUtil.createJwt(userEmail, 60 * 60 * 10L);
-        response.addHeader("Authorization", "Bearer " + accessToken);
-        response.addHeader("Refresh-Token", "Bearer " + refreshToken);
+        String accessToken = jwtUtil.createJwt(userEmail, 60 * 60L * 10L);
+        String refreshToken = jwtUtil.createJwt(userEmail, 60 * 60 * 24L * 7L);
+
+        Cookie accessTokenCookie = new Cookie("accessToken", accessToken);
+        accessTokenCookie.setHttpOnly(true);
+        accessTokenCookie.setSecure(true);
+        accessTokenCookie.setPath("/");
+        accessTokenCookie.setMaxAge(60 * 60 * 10);
+
+
+        Cookie refreshTokenCookie = new Cookie("refreshToken", refreshToken);
+        refreshTokenCookie.setHttpOnly(true);
+        refreshTokenCookie.setSecure(true);
+        refreshTokenCookie.setPath("/");
+        refreshTokenCookie.setMaxAge(60 * 60 * 24 * 7);
+
+        response.addCookie(accessTokenCookie);
+        response.addCookie(refreshTokenCookie);
     }
 
     @Override

--- a/src/main/java/com/maptracker/issuemap/domain/user/controller/UserController.java
+++ b/src/main/java/com/maptracker/issuemap/domain/user/controller/UserController.java
@@ -5,6 +5,7 @@ import com.maptracker.issuemap.domain.user.dto.UserSignupRequest;
 import com.maptracker.issuemap.domain.user.dto.UserSignupResponse;
 import com.maptracker.issuemap.domain.user.service.UserAuthService;
 import com.maptracker.issuemap.domain.user.service.UserService;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -25,6 +26,12 @@ public class UserController {
     @PostMapping("/login")
     public ResponseEntity<Object> login(@RequestBody UserLoginRequest request) {
         return ResponseEntity.ok(userAuthService.login(request));
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout(HttpServletResponse response) {
+        userAuthService.logout(response);
+        return ResponseEntity.ok().build();
     }
 
 

--- a/src/main/java/com/maptracker/issuemap/domain/user/service/UserAuthService.java
+++ b/src/main/java/com/maptracker/issuemap/domain/user/service/UserAuthService.java
@@ -5,6 +5,8 @@ import com.maptracker.issuemap.domain.user.dto.UserLoginRequest;
 import com.maptracker.issuemap.domain.user.entity.User;
 import com.maptracker.issuemap.domain.user.exception.UserException;
 import com.maptracker.issuemap.domain.user.repository.UserRepository;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -19,6 +21,24 @@ public class UserAuthService {
     public User login(UserLoginRequest request) {
         return validateEmailAndPassword(request.getEmail(), request.getPassword());
     }
+
+    public void logout(HttpServletResponse response) {
+        Cookie accessTokenCookie = new Cookie("accessToken", null);
+        accessTokenCookie.setHttpOnly(true);
+        accessTokenCookie.setSecure(true);
+        accessTokenCookie.setPath("/");
+        accessTokenCookie.setMaxAge(1);
+
+        Cookie refreshTokenCookie = new Cookie("refreshToken", null);
+        refreshTokenCookie.setHttpOnly(true);
+        refreshTokenCookie.setSecure(true);
+        refreshTokenCookie.setPath("/");
+        refreshTokenCookie.setMaxAge(1);
+
+        response.addCookie(accessTokenCookie);
+        response.addCookie(refreshTokenCookie);
+    }
+
 
     private User validateEmailAndPassword(String email, String rawPassword) {
         return userRepository.findByEmail(email)


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [X] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 코드 리팩토링
- [ ] 테스트 코드 추가 및 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
- develop

### 이슈
- 이슈 번호 : #35 

### 변경 사항
로그아웃 API 구현하였고, `swagger`에서 `jwt` 토큰을 헤더에 담아서 요청할 수 있도록 설정 파일을 추가하였습니다.

현재 로그인과 로그아웃의 기능 흐름이 다음과 같습니다.
`/api/users/login` 요청 -> 로그인 성공 시 `AcessToken` 과 `Refresh Token` 토큰을 생성하고 클라이언트에게 쿠키로 전달 할 수 있도록 하였고, 로그아웃 시 쿠키의 저장되어있는 `AcessToken` 과 `Refresh Token`의 시간을 만료시키는것으로 코드를 작성하였습니다.

이후 요청에서는 `JwtFilter`에서 사용자의 토큰을 검증하고, 유효한 경우에만 `SecurityContextHolder`에 사용자의 인증 토큰을 담는방식으로 구현하였고, 실제 컨트롤러에서 `@AuthenticationPrincipal` 어노테이션을 사용하여, 인증 토큰에 담긴 정보를 접근할 수 있었습니다.

현재 기능들은 모두 정상적으로 동작하지만 이런 코드의 흐름이 올바른지 궁금합니다.
추가적으로 토큰 정보를 클라이언트에게 어떤 방식으로 전달해주는지 궁금합니다 (예) 쿠키, 로컬 스토리지, 세션 스토리지)

이전 코드는 `response.header(토큰정보)` 로 클라이언트에게 일회성으로 토큰 정보를 전달해주는 방식을 선택하였는데, 
이후 클라이언트가 요청을 보낼 때 토큰의 정보가 저장되어있지 않아 헤더에 토큰을 포함하여 요청을 전달할 수 없었습니다. 그래서 현재 토큰 저장 방식은 쿠키를 사용했는데 잘못 사용한것인지 조금 더 좋은 방향이 있는지 궁금하고, 전체적인 코드가 올바른지 궁금합니다!



### 테스트 결과
x
