### PR TITLE
[#38] 팀 프로젝트 수정, 삭제 API 구현

### DIFF
--- a/src/main/java/com/maptracker/issuemap/domain/project/controller/ProjectController.java
+++ b/src/main/java/com/maptracker/issuemap/domain/project/controller/ProjectController.java
@@ -2,7 +2,9 @@ package com.maptracker.issuemap.domain.project.controller;
 
 import com.maptracker.issuemap.domain.project.dto.ProjectRequestDto;
 import com.maptracker.issuemap.domain.project.dto.ProjectResponseDto;
+import com.maptracker.issuemap.domain.project.dto.ProjectUpdateRequestDto;
 import com.maptracker.issuemap.domain.project.service.ProjectService;
+import com.maptracker.issuemap.domain.team.dto.TeamResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -12,13 +14,12 @@ import io.swagger.v3.oas.annotations.Parameter;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/projects")
+@RequestMapping("/api/teams/{teamId}/projects")
 @RequiredArgsConstructor
 public class ProjectController {
 
     private final ProjectService projectService;
 
-    // 프로젝트 생성
     @Operation(summary = "프로젝트 생성", description = "새로운 프로젝트를 생성합니다.")
     @PostMapping
     public ResponseEntity<ProjectResponseDto> createProject(@RequestBody ProjectRequestDto projectRequestDto) {
@@ -26,12 +27,25 @@ public class ProjectController {
         return ResponseEntity.ok(projectResponseDto);
     }
 
-    // 프로젝트 조회
     @Operation(summary = "특정 프로젝트 조회", description = "특정 프로젝트의 상세 정보를 조회합니다.")
     @GetMapping("/{projectId}")
     public ResponseEntity<ProjectResponseDto> getProjectById(@Parameter(description = "조회할 프로젝트의 ID", required = true)
                                                                  @PathVariable Long projectId) {
         ProjectResponseDto projects = projectService.getProjectById(projectId);
         return ResponseEntity.ok(projects);
+    }
+
+    @Operation(summary = "특정 프로젝트 수정", description = "특정 프로젝트의 상세 정보를 수정합니다.")
+    @PutMapping("/{projectId}")
+    public ResponseEntity<ProjectResponseDto> updateProject(@PathVariable Long projectId, @RequestBody ProjectUpdateRequestDto projectUpdateRequestDto) {
+        ProjectResponseDto projectResponseDto = projectService.updateProject(projectId, projectUpdateRequestDto);
+        return ResponseEntity.ok(projectResponseDto);
+    }
+
+    @Operation(summary = "특정 프로젝트 삭제", description = "특정 프로젝트를 삭제합니다.")
+    @DeleteMapping("/{projectId}")
+    public ResponseEntity<Void> deleteProject(@PathVariable Long projectId) {
+        projectService.deleteProject(projectId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/maptracker/issuemap/domain/project/dto/ProjectResponseDto.java
+++ b/src/main/java/com/maptracker/issuemap/domain/project/dto/ProjectResponseDto.java
@@ -2,11 +2,13 @@ package com.maptracker.issuemap.domain.project.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
+@Builder
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor

--- a/src/main/java/com/maptracker/issuemap/domain/project/dto/ProjectUpdateRequestDto.java
+++ b/src/main/java/com/maptracker/issuemap/domain/project/dto/ProjectUpdateRequestDto.java
@@ -1,0 +1,14 @@
+package com.maptracker.issuemap.domain.project.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProjectUpdateRequestDto {
+    @Schema(description = "팀 이름", example = "MapTrackers")
+    private String projectName;
+}

--- a/src/main/java/com/maptracker/issuemap/domain/project/service/ProjectService.java
+++ b/src/main/java/com/maptracker/issuemap/domain/project/service/ProjectService.java
@@ -2,6 +2,7 @@ package com.maptracker.issuemap.domain.project.service;
 
 import com.maptracker.issuemap.domain.project.dto.ProjectRequestDto;
 import com.maptracker.issuemap.domain.project.dto.ProjectResponseDto;
+import com.maptracker.issuemap.domain.project.dto.ProjectUpdateRequestDto;
 import com.maptracker.issuemap.domain.project.entity.Project;
 import com.maptracker.issuemap.domain.project.repository.ProjectRepository;
 import com.maptracker.issuemap.domain.team.entity.Team;
@@ -32,25 +33,52 @@ public class ProjectService {
 
         Project savedProject = projectRepository.save(project);
 
-        return new ProjectResponseDto(
-                savedProject.getId(),
-                savedProject.getProjectName(),
-                savedProject.getCreatedAt(),
-                savedProject.getTeam().getId(),
-                savedProject.getTeam().getTeamName()
-        );
+        return ProjectResponseDto.builder()
+                .id(savedProject.getId())
+                .projectName(savedProject.getProjectName())
+                .createdAt(savedProject.getCreatedAt())
+                .teamId(savedProject.getTeam().getId())
+                .teamName(savedProject.getTeam().getTeamName())
+                .build();
     }
 
     // 프로젝트 조회
     public ProjectResponseDto getProjectById(Long projectId) {
         Project project = projectRepository.findById(projectId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 프로젝트를 찾을 수 없습니다."));
-        return new ProjectResponseDto(
-                project.getId(),
-                project.getProjectName(),
-                project.getCreatedAt(),
-                project.getTeam().getId(),
-                project.getTeam().getTeamName()
-        );
+        return ProjectResponseDto.builder()
+                .id(project.getId())
+                .projectName(project.getProjectName())
+                .createdAt(project.getCreatedAt())
+                .teamId(project.getTeam().getId())
+                .teamName(project.getTeam().getTeamName())
+                .build();
+    }
+
+    // 프로젝트 수정
+    public ProjectResponseDto updateProject(Long projectId, ProjectUpdateRequestDto projectUpdateRequestDto) {
+        Project project = projectRepository.findById(projectId)
+                .orElseThrow(() -> new IllegalArgumentException("Project not found"));
+
+        // 수정 로직
+        project.setProjectName(projectUpdateRequestDto.getProjectName());
+
+        Project updatedProject = projectRepository.save(project);
+
+        return ProjectResponseDto.builder()
+                .id(updatedProject.getId())
+                .projectName(updatedProject.getProjectName())
+                .createdAt(updatedProject.getCreatedAt())
+                .teamId(updatedProject.getTeam().getId())
+                .teamName(updatedProject.getTeam().getTeamName())
+                .build();
+    }
+
+    // 프로젝트 삭제
+    public void deleteProject(Long projectId) {
+        if (!projectRepository.existsById(projectId)) {
+            throw new IllegalArgumentException("Project not found with id: " + projectId);
+        }
+        projectRepository.deleteById(projectId);
     }
 }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [X] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [X] 코드 리팩토링
- [ ] 테스트 코드 추가 및 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
develop

### 이슈
[#38 ]

### 변경 사항
- feat: 팀 프로젝트 수정, 삭제 API 구현
- refactor: set 대신 builder 패턴 적용, api url 수정
<img width="808" alt="image" src="https://github.com/user-attachments/assets/c390825d-97d6-49f3-89f6-7fa40d315932" />
=> 최종적으로 수정했습니다.
 팀 생성 후 그 팀에 대한 프로젝트를 생성하기로 해서 api url 과 로직을 이렇게 반영하였는데
한번씩 확인해주시면 감사하겠습니다!

### 테스트 결과
수정 API
<img width="477" alt="프로젝트 수정 API" src="https://github.com/user-attachments/assets/f86796b5-d235-4783-8bc4-c6bb2ebb9c08" />

삭제 API
<img width="953" alt="프로젝트 삭제 API" src="https://github.com/user-attachments/assets/deac3cb5-6b3e-4c21-8192-464eda56f67f" />

### 추가적으로 진행 사항 보고
현재 팀과 프로젝트에 대한 생성 조회 수정 삭제 API 전체적으로 구현 완료하였고 
서비스 계층의 테스트 코드 작성 예정입니다. 
그 후에는 요한님께서 코멘트 남겨주셨던 fetchType을 LAZY에서 EAGER로 
바꾸었던 부분 다시 한번 확인해보도록 하겠습니다.