### PR TITLE
[#55] RestTemplate을 활용한 외부 문의 API 통합 구현

### DIFF
--- a/src/main/java/com/maptracker/issuemap/common/config/RestTemplateConfig.java
+++ b/src/main/java/com/maptracker/issuemap/common/config/RestTemplateConfig.java
@@ -1,0 +1,15 @@
+package com.maptracker.issuemap.common.config;
+
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+
+    @Bean
+    public RestTemplate restTemplate(RestTemplateBuilder builder) {
+        return builder.build();
+    }
+}

--- a/src/main/java/com/maptracker/issuemap/common/config/SecurityConfig.java
+++ b/src/main/java/com/maptracker/issuemap/common/config/SecurityConfig.java
@@ -74,6 +74,7 @@ public class SecurityConfig {
                         .requestMatchers("/api/subissues/**").permitAll()
                         .requestMatchers("/api/issuehistories/**").permitAll()
                         .requestMatchers("/api/users/**").permitAll()
+                        .requestMatchers("/api/inquiries/**").permitAll()
                         .anyRequest().authenticated()
                 );
         http

--- a/src/main/java/com/maptracker/issuemap/domain/inquiry/controller/InquiryController.java
+++ b/src/main/java/com/maptracker/issuemap/domain/inquiry/controller/InquiryController.java
@@ -1,0 +1,80 @@
+package com.maptracker.issuemap.domain.inquiry.controller;
+
+import com.maptracker.issuemap.domain.inquiry.dto.InquiryRequestDto;
+import com.maptracker.issuemap.domain.inquiry.dto.ResponseRequestDto;
+import com.maptracker.issuemap.domain.inquiry.service.InquiryService;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.*;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/inquiries")
+@RequiredArgsConstructor
+public class InquiryController {
+
+    private final InquiryService inquiryService;
+
+    @Operation(summary = "문의 작성", description = "새로운 문의를 작성합니다.")
+    @PostMapping
+    public ResponseEntity<String> createInquiry(
+            @RequestBody InquiryRequestDto request,
+            @RequestHeader("Authorization") String authorizationHeader) {
+
+        return inquiryService.createInquiry(request, authorizationHeader);
+    }
+
+    @Operation(summary = "전체 문의 조회", description = "전체 문의를 조회합니다.")
+    @GetMapping
+    public ResponseEntity<String> getAllInquiries() {
+        return inquiryService.getAllInquiries();
+    }
+
+    @Operation(summary = "특정 문의 조회", description = "특정 문의를 조회합니다.")
+    @GetMapping("/{inquiryId}")
+    public ResponseEntity<String> getInquiryDetail(@PathVariable Long inquiryId) {
+        return inquiryService.getInquiryDetail(inquiryId);
+    }
+
+    @Operation(summary = "문의 삭제", description = "문의를 삭제합니다.")
+    @DeleteMapping("/{inquiryId}")
+    public ResponseEntity<String> deleteInquiry(@PathVariable Long inquiryId) {
+        return inquiryService.deleteInquiry(inquiryId);
+    }
+
+    @Operation(summary = "답변 작성", description = "문의 답변을 작성합니다.")
+    @PostMapping("/{inquiryId}/responses")
+    public ResponseEntity<String> createResponse(
+            @PathVariable Long inquiryId,
+            @RequestBody ResponseRequestDto request) {
+
+        return inquiryService.createResponse(inquiryId, request);
+    }
+
+    @Operation(summary = "답변 수정", description = "문의 답변을 수정합니다.")
+    @PutMapping("/{inquiryId}/responses/{responseId}")
+    public ResponseEntity<String> updateResponse(
+            @PathVariable Long inquiryId,
+            @PathVariable Long responseId,
+            @RequestBody ResponseRequestDto request) {
+
+        return inquiryService.updateResponse(inquiryId, responseId, request);
+    }
+
+    @Operation(summary = "답변 조회", description = "문의 답변을 조회합니다.")
+    @GetMapping("/{inquiryId}/responses")
+    public ResponseEntity<String> getResponses(@PathVariable Long inquiryId) {
+        return inquiryService.getResponses(inquiryId);
+    }
+
+    @Operation(summary = "답변 상태 변경", description = "문의 답변 상태를 변경합니다.")
+    @PatchMapping("/{inquiryId}/responses/{responseId}/status")
+    public ResponseEntity<String> updateStatus(
+            @PathVariable Long inquiryId,
+            @PathVariable Long responseId,
+            @RequestBody ResponseRequestDto request) {
+
+        return inquiryService.updateStatus(inquiryId, responseId, request);
+    }
+}

--- a/src/main/java/com/maptracker/issuemap/domain/inquiry/dto/InquiryRequestDto.java
+++ b/src/main/java/com/maptracker/issuemap/domain/inquiry/dto/InquiryRequestDto.java
@@ -1,0 +1,10 @@
+package com.maptracker.issuemap.domain.inquiry.dto;
+
+import lombok.Data;
+import lombok.Getter;
+
+@Data
+public class InquiryRequestDto {
+    private String title;
+    private String content;
+}

--- a/src/main/java/com/maptracker/issuemap/domain/inquiry/dto/ResponseRequestDto.java
+++ b/src/main/java/com/maptracker/issuemap/domain/inquiry/dto/ResponseRequestDto.java
@@ -1,0 +1,8 @@
+package com.maptracker.issuemap.domain.inquiry.dto;
+
+import lombok.Data;
+
+@Data
+public class ResponseRequestDto {
+    private String content;
+}

--- a/src/main/java/com/maptracker/issuemap/domain/inquiry/service/InquiryService.java
+++ b/src/main/java/com/maptracker/issuemap/domain/inquiry/service/InquiryService.java
@@ -1,0 +1,78 @@
+package com.maptracker.issuemap.domain.inquiry.service;
+
+import com.maptracker.issuemap.domain.inquiry.dto.InquiryRequestDto;
+import com.maptracker.issuemap.domain.inquiry.dto.ResponseRequestDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+@RequiredArgsConstructor
+public class InquiryService {
+
+    private final RestTemplate restTemplate;
+
+    private static final String BASE_URL = "http://localhost:8081/api/inquiries";
+    private static final String BEARER_PREFIX = "Bearer ";
+    private static final String INVALID_AUTH_HEADER = "Invalid Authorization header format.";
+
+    // 문의를 생성합니다.
+    public ResponseEntity<String> createInquiry(InquiryRequestDto request, String authorizationHeader) {
+        HttpHeaders headers = createHeaders(authorizationHeader);
+        HttpEntity<InquiryRequestDto> entity = new HttpEntity<>(request, headers);
+        return restTemplate.exchange(BASE_URL, HttpMethod.POST, entity, String.class);
+    }
+
+    // 나머지 요청은 공통적으로 Authorization 처리 (Service 내부에서 처리)
+    private HttpHeaders createHeaders(String authorizationHeader) {
+        if (authorizationHeader == null || !authorizationHeader.startsWith(BEARER_PREFIX)) {
+            throw new IllegalArgumentException(INVALID_AUTH_HEADER);
+        }
+        String token = authorizationHeader.substring(BEARER_PREFIX.length());
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", BEARER_PREFIX + token);
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        return headers;
+    }
+
+    // 전체 문의를 조회합니다.
+    public ResponseEntity<String> getAllInquiries() {
+        return restTemplate.exchange(BASE_URL, HttpMethod.GET, null, String.class);
+    }
+
+    // 특정 문의를 조회합니다.
+    public ResponseEntity<String> getInquiryDetail(Long inquiryId) {
+        return restTemplate.exchange(BASE_URL + "/" + inquiryId, HttpMethod.GET, null, String.class);
+    }
+
+    // 특정 문의를 삭제합니다.
+    public ResponseEntity<String> deleteInquiry(Long inquiryId) {
+        return restTemplate.exchange(BASE_URL + "/" + inquiryId, HttpMethod.DELETE, null, String.class);
+    }
+
+    // 특정 문의에 답변을 생성합니다.
+    public ResponseEntity<String> createResponse(Long inquiryId, ResponseRequestDto request) {
+        HttpEntity<ResponseRequestDto> entity = new HttpEntity<>(request);
+        return restTemplate.exchange(BASE_URL + "/" + inquiryId + "/responses", HttpMethod.POST, entity, String.class);
+    }
+
+    // 특정 답변을 수정합니다.
+    public ResponseEntity<String> updateResponse(Long inquiryId, Long responseId, ResponseRequestDto request) {
+        HttpEntity<ResponseRequestDto> entity = new HttpEntity<>(request);
+        return restTemplate.exchange(BASE_URL + "/" + inquiryId + "/responses/" + responseId,
+                HttpMethod.PUT, entity, String.class);
+    }
+
+    // 특정 문의에 대한 모든 답변을 조회합니다.
+    public ResponseEntity<String> getResponses(Long inquiryId) {
+        return restTemplate.exchange(BASE_URL + "/" + inquiryId + "/responses", HttpMethod.GET, null, String.class);
+    }
+
+    // 특정 답변의 상태를 업데이트합니다.
+    public ResponseEntity<String> updateStatus(Long inquiryId, Long responseId, ResponseRequestDto request) {
+        HttpEntity<ResponseRequestDto> entity = new HttpEntity<>(request);
+        return restTemplate.exchange(BASE_URL + "/" + inquiryId + "/responses/" + responseId + "/status",
+                HttpMethod.PUT, entity, String.class);
+    }
+}


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [X] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 코드 리팩토링
- [ ] 테스트 코드 추가 및 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
ex) develop

### 이슈
[#55]

### 변경 사항
- 외주 맡긴 로직 RestTemplate 사용하여 요청 응답 구현했습니다.
- 배포 진행시 BASE_URL 수정하겠습니다.

### 테스트 결과
- 외부 API를 호출하는 코드는 의존성이 높아 변경 가능성이 크기 때문에, 테스트 작성에서 제외했습니다.
